### PR TITLE
Fix volume progress bar scaling and add overflow hidden

### DIFF
--- a/src/app/components/Visualization/Volume/index.tsx
+++ b/src/app/components/Visualization/Volume/index.tsx
@@ -41,7 +41,7 @@ export const Volume = ({ audioContext, audioGainNode }: Props) => {
 				<div className={styles.progressBackground}>
 					<div
 						className={styles.progressBar}
-						style={{ "--progress": masterVolume * 2 } as CSSProperties}
+						style={{ "--progress": masterVolume } as CSSProperties}
 					></div>
 				</div>
 			</div>

--- a/src/app/components/Visualization/Volume/styles.module.css
+++ b/src/app/components/Visualization/Volume/styles.module.css
@@ -27,6 +27,7 @@
 	position: relative;
 	width: 100%;
 	height: 2px;
+	overflow: hidden;
 	background-color: var(--color-border);
 }
 


### PR DESCRIPTION
Corrects the progress bar scaling by removing the multiplication by 2 on the masterVolume value and adds overflow: hidden to the progress background for better visual containment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the volume progress bar visualization for more accurate scaling.
  * Improved the appearance of the volume bar by preventing visual overflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->