### PR TITLE
Update frequency visualization colors and add border

### DIFF
--- a/src/app/components/Visualization/Frequency/styles.module.css
+++ b/src/app/components/Visualization/Frequency/styles.module.css
@@ -2,4 +2,5 @@
 	display: block;
 	width: calc(200 * var(--px-to-vw));
 	height: calc(200 * var(--px-to-vw));
+	border: 1px solid var(--color-border);
 }

--- a/src/hooks/useFrequency.ts
+++ b/src/hooks/useFrequency.ts
@@ -60,7 +60,7 @@ export const useFrequency = ({
 		}
 
 		if (!canvasContextRef.current) return;
-		canvasContextRef.current.fillStyle = "rgb(0, 0, 0)";
+		canvasContextRef.current.fillStyle = "rgb(255, 255, 255)";
 		canvasContextRef.current.fillRect(0, 0, canvasWidth, canvasHeight);
 
 		const bars = calculateFrequencyBars(dataArrayRef.current, canvasWidth);
@@ -93,7 +93,7 @@ const calculateFrequencyBars = (
 	for (let i = 0; i < bufferLength; i++) {
 		const barHeight = dataArray[i] * 0.8;
 
-		const color = `rgb(255,255,255)`;
+		const color = `rgb(0,0,0)`;
 
 		bars.push({
 			height: barHeight,


### PR DESCRIPTION
Changed the canvas background fill color to white and the frequency bar color to black in useFrequency.ts. Added a border to the frequency visualization container in styles.module.css for improved visual clarity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added a border to the frequency visualization canvas for improved visual clarity.
  * Updated the color scheme of the frequency visualization: the background is now white and the frequency bars are black, providing a reversed and cleaner appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->